### PR TITLE
AttributeError: module 'pymysql.constants' has no attribute 'FLAG'

### DIFF
--- a/torndb.py
+++ b/torndb.py
@@ -41,6 +41,7 @@ try:
     import pymysql.connections
     import pymysql.converters
     import pymysql.cursors
+    import pymysql.constants.FLAG
 
 
 except ImportError:


### PR DESCRIPTION
I was getting ```AttributeError: module 'pymysql.constants' has no attribute 'FLAG'``` error when I try after settings up mysql details 